### PR TITLE
Fixed wordBanksHTML ID

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -27,7 +27,7 @@ ul {
     margin: 0 auto;
 }
 
-#wordBanks {
+#wordBanksHTML {
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;


### PR DESCRIPTION
Fixed wordbanksHTML ID in CSS to correctly display word bank options along the top of the screen.